### PR TITLE
add --no-deps to pip install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ source:
     - py27_noffmpeg.patch  # [win and py27]
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . -vvv"
+  number: 1
+  script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . -vvv"
 
 requirements:
   build:


### PR DESCRIPTION
avoids pulling in dependencies. Current packages include numpy.

closes #15